### PR TITLE
fix: Fixed the issue of examples failing to compile under MSVC

### DIFF
--- a/examples/context-engineering/context-engineering.cpp
+++ b/examples/context-engineering/context-engineering.cpp
@@ -15,7 +15,13 @@
 #include <functional>
 #include <iostream>
 #include <string>
+
+#if _WIN32
+#include <io.h>
+#define isatty _isatty
+#else
 #include <unistd.h>
+#endif // _WIN32
 
 static constexpr size_t DEFAULT_MAX_TOOL_CALLS = 1;
 

--- a/examples/context-engineering/context-engineering.cpp
+++ b/examples/context-engineering/context-engineering.cpp
@@ -8,6 +8,7 @@
 #include "llama.h"
 #include "logging_callback.h"
 #include "model.h"
+#include "platform_compat.h"
 #include "tool.h"
 #include <algorithm>
 #include <cstdio>
@@ -15,13 +16,6 @@
 #include <functional>
 #include <iostream>
 #include <string>
-
-#ifdef _WIN32
-#include <io.h>
-#define isatty _isatty
-#else
-#include <unistd.h>
-#endif // _WIN32
 
 static constexpr size_t DEFAULT_MAX_TOOL_CALLS = 1;
 

--- a/examples/context-engineering/context-engineering.cpp
+++ b/examples/context-engineering/context-engineering.cpp
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <string>
 
-#if _WIN32
+#ifdef _WIN32
 #include <io.h>
 #define isatty _isatty
 #else

--- a/examples/memory/memory.cpp
+++ b/examples/memory/memory.cpp
@@ -15,7 +15,13 @@
 #include <iostream>
 #include <map>
 #include <string>
+
+#if _WIN32
+#include <io.h>
+#define isatty _isatty
+#else
 #include <unistd.h>
+#endif // _WIN32
 
 using agent_cpp::json;
 

--- a/examples/memory/memory.cpp
+++ b/examples/memory/memory.cpp
@@ -16,13 +16,6 @@
 #include <map>
 #include <string>
 
-#if _WIN32
-#include <io.h>
-#define isatty _isatty
-#else
-#include <unistd.h>
-#endif // _WIN32
-
 using agent_cpp::json;
 
 class MemoryStore

--- a/examples/multi-agent/multi-agent.cpp
+++ b/examples/multi-agent/multi-agent.cpp
@@ -15,7 +15,13 @@
 #include <iostream>
 #include <memory>
 #include <string>
+
+#if _WIN32
+#include <io.h>
+#define isatty _isatty
+#else
 #include <unistd.h>
+#endif // _WIN32
 
 using agent_cpp::json;
 

--- a/examples/multi-agent/multi-agent.cpp
+++ b/examples/multi-agent/multi-agent.cpp
@@ -16,13 +16,6 @@
 #include <memory>
 #include <string>
 
-#if _WIN32
-#include <io.h>
-#define isatty _isatty
-#else
-#include <unistd.h>
-#endif // _WIN32
-
 using agent_cpp::json;
 
 class MathAgent;

--- a/examples/shared/chat_loop.h
+++ b/examples/shared/chat_loop.h
@@ -5,8 +5,14 @@
 #include <cstdio>
 #include <iostream>
 #include <string>
-#include <unistd.h>
 #include <vector>
+
+#if _WIN32
+#include <io.h>
+#define isatty _isatty
+#else
+#include <unistd.h>
+#endif // _WIN32
 
 // Run an interactive chat loop with the given agent.
 // Reads user input from stdin and prints agent responses to stdout.
@@ -48,3 +54,7 @@ run_chat_loop(agent_cpp::Agent& agent)
 
     printf("\n👋 Goodbye!\n");
 }
+
+#if _WIN32
+#undef isatty
+#endif // _WIN32

--- a/examples/shared/chat_loop.h
+++ b/examples/shared/chat_loop.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#if _WIN32
+#ifdef _WIN32
 #include <io.h>
 #define isatty _isatty
 #else
@@ -55,6 +55,6 @@ run_chat_loop(agent_cpp::Agent& agent)
     printf("\n👋 Goodbye!\n");
 }
 
-#if _WIN32
+#ifdef _WIN32
 #undef isatty
 #endif // _WIN32

--- a/examples/shared/chat_loop.h
+++ b/examples/shared/chat_loop.h
@@ -2,17 +2,11 @@
 
 #include "agent.h"
 #include "chat.h"
+#include "platform_compat.h"
 #include <cstdio>
 #include <iostream>
 #include <string>
 #include <vector>
-
-#ifdef _WIN32
-#include <io.h>
-#define isatty _isatty
-#else
-#include <unistd.h>
-#endif // _WIN32
 
 // Run an interactive chat loop with the given agent.
 // Reads user input from stdin and prints agent responses to stdout.
@@ -54,7 +48,3 @@ run_chat_loop(agent_cpp::Agent& agent)
 
     printf("\n👋 Goodbye!\n");
 }
-
-#ifdef _WIN32
-#undef isatty
-#endif // _WIN32

--- a/examples/shared/logging_callback.h
+++ b/examples/shared/logging_callback.h
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <string>
 
-#if _WIN32
+#ifdef _WIN32
 #include <io.h>
 #define isatty _isatty
 #else
@@ -54,6 +54,6 @@ class LoggingCallback : public agent_cpp::Callback
     }
 };
 
-#if _WIN32
+#ifdef _WIN32
 #undef isatty
 #endif // _WIN32

--- a/examples/shared/logging_callback.h
+++ b/examples/shared/logging_callback.h
@@ -4,7 +4,13 @@
 #include "tool_result.h"
 #include <cstdio>
 #include <string>
+
+#if _WIN32
+#include <io.h>
+#define isatty _isatty
+#else
 #include <unistd.h>
+#endif // _WIN32
 
 // Logging callback to display tool execution information.
 // Shared across examples to provide consistent tool call logging.
@@ -47,3 +53,7 @@ class LoggingCallback : public agent_cpp::Callback
         }
     }
 };
+
+#if _WIN32
+#undef isatty
+#endif // _WIN32

--- a/examples/shared/logging_callback.h
+++ b/examples/shared/logging_callback.h
@@ -1,16 +1,10 @@
 #pragma once
 
 #include "callbacks.h"
+#include "platform_compat.h"
 #include "tool_result.h"
 #include <cstdio>
 #include <string>
-
-#ifdef _WIN32
-#include <io.h>
-#define isatty _isatty
-#else
-#include <unistd.h>
-#endif // _WIN32
 
 // Logging callback to display tool execution information.
 // Shared across examples to provide consistent tool call logging.
@@ -53,7 +47,3 @@ class LoggingCallback : public agent_cpp::Callback
         }
     }
 };
-
-#ifdef _WIN32
-#undef isatty
-#endif // _WIN32

--- a/examples/shared/platform_compat.h
+++ b/examples/shared/platform_compat.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// Small compatibility shim so the examples build with MSVC, which does not
+// ship <unistd.h> and prefixes the POSIX names with an underscore.
+// Shared across examples to avoid repeating the same #ifdef block.
+
+#ifdef _WIN32
+#include <io.h>
+
+#define isatty _isatty
+#define popen _popen
+#define pclose _pclose
+
+#else
+#include <unistd.h>
+#endif // _WIN32

--- a/examples/shell/shell.cpp
+++ b/examples/shell/shell.cpp
@@ -15,7 +15,16 @@
 #include <iostream>
 #include <memory>
 #include <string>
+
+#if _WIN32
+#include <io.h>
+#include <stdio.h>
+#define isatty _isatty
+#define popen _popen
+#define pclose _pclose
+#else
 #include <unistd.h>
+#endif // _WIN32
 
 using agent_cpp::json;
 using agent_cpp::ToolExecutionSkipped;

--- a/examples/shell/shell.cpp
+++ b/examples/shell/shell.cpp
@@ -6,6 +6,7 @@
 #include "error_recovery_callback.h"
 #include "llama.h"
 #include "model.h"
+#include "platform_compat.h"
 #include "tool.h"
 
 #include <algorithm>
@@ -15,16 +16,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-
-#ifdef _WIN32
-#include <io.h>
-#include <stdio.h>
-#define isatty _isatty
-#define popen _popen
-#define pclose _pclose
-#else
-#include <unistd.h>
-#endif // _WIN32
 
 using agent_cpp::json;
 using agent_cpp::ToolExecutionSkipped;

--- a/examples/shell/shell.cpp
+++ b/examples/shell/shell.cpp
@@ -16,7 +16,7 @@
 #include <memory>
 #include <string>
 
-#if _WIN32
+#ifdef _WIN32
 #include <io.h>
 #include <stdio.h>
 #define isatty _isatty

--- a/examples/tracing/tracing.cpp
+++ b/examples/tracing/tracing.cpp
@@ -28,7 +28,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <unistd.h>
 #include <vector>
 
 namespace trace_api = opentelemetry::trace;


### PR DESCRIPTION
In MSVC, since `<unistd.h>` and its contained `isatty` do not exist, you can use `<io.h>`'s `_isatty` instead.